### PR TITLE
fix: ImplementationCache.get/1 failed on empty rule_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- [TD-4938] `ImplementationCache.get/1` was failing for ruleless implementations
+
 ## [4.45.0] 2022-05-26
 
 ### Changed

--- a/lib/td_cache/implementation_cache.ex
+++ b/lib/td_cache/implementation_cache.ex
@@ -7,7 +7,6 @@ defmodule TdCache.ImplementationCache do
   alias TdCache.Redix
   alias TdCache.RuleCache
   alias TdCache.Utils.MapHelpers
-  # alias TdCache.SystemCache
 
   ## Client API
 
@@ -152,8 +151,14 @@ defmodule TdCache.ImplementationCache do
     end
   end
 
-  defp maybe_get_rule(%{rule_id: rule_id}) when not is_nil(rule_id),
-    do: RuleCache.get(String.to_integer(rule_id))
+  defp maybe_get_rule(%{rule_id: ""}), do: {:ok, nil}
+
+  defp maybe_get_rule(%{rule_id: rule_id}) when is_binary(rule_id) do
+    case Integer.parse(rule_id) do
+      {id, ""} -> RuleCache.get(id)
+      _ -> {:ok, nil}
+    end
+  end
 
   defp maybe_get_rule(_), do: {:ok, nil}
 


### PR DESCRIPTION
JIRA: TD-4938